### PR TITLE
Expand Breadcrumb options

### DIFF
--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -90,3 +90,111 @@
 </Breadcrumbs>
 ```
 
+#### `renders array of crumbs, custom label fn, styling, without initial caret`
+
+```
+<Breadcrumbs
+  caretBeforeCrumb={false}
+  getBreadcrumbLabel={[Function]}
+  getElements={[Function]}
+  styling={
+    Object {
+      "data-css-c6mfa5": "",
+    }
+  }
+>
+  <div
+    data-css-c6mfa5=""
+  >
+    <Route
+      key="Assignments | Caseflow Reader"
+      path="/"
+      render={[Function]}
+    >
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/"
+      >
+        <Link
+          replace={false}
+          to="/"
+          type={null}
+        >
+          <a
+            href="/"
+            onClick={[Function]}
+            type={null}
+          >
+            Assignments | Caseflow Reader
+          </a>
+        </Link>
+      </Link>
+        &gt;  
+    </Route>
+    <Route
+      key="Claims Folder"
+      path="/:vacolsId/documents"
+      render={[Function]}
+    >
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents"
+      >
+        <Link
+          replace={false}
+          to="/vacolsId/documents"
+          type={null}
+        >
+          <a
+            href="/vacolsId/documents"
+            onClick={[Function]}
+            type={null}
+          >
+            Claims Folder
+          </a>
+        </Link>
+      </Link>
+        &gt;  
+    </Route>
+    <Route
+      key="Document Viewer"
+      path="/:vacolsId/documents/:docId"
+      render={[Function]}
+    >
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents/docId"
+      >
+        <Link
+          replace={false}
+          to="/vacolsId/documents/docId"
+          type={null}
+        >
+          <a
+            href="/vacolsId/documents/docId"
+            onClick={[Function]}
+            type={null}
+          >
+            Document Viewer
+          </a>
+        </Link>
+      </Link>
+    </Route>
+  </div>
+</Breadcrumbs>
+```

--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -3,87 +3,90 @@
 #### `renders with props`
 
 ```
-<Breadcrumbs>
-  <span>
+<Breadcrumbs
+  caretBeforeCrumb={true}
+  getBreadcrumbLabel={[Function]}
+  getElements={[Function]}
+  styling={
+    Object {
+      "data-css-1mdtwij": "",
+    }
+  }
+>
+  <div
+    data-css-1mdtwij=""
+  >
     <Route
       key="Claims Folder"
       path="/:vacolsId/documents"
       render={[Function]}
     >
-      <span
-        data-css-1mdtwij=""
+        &gt;  
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents"
       >
-        <h2
-          className="cf-application-title"
-          id="page-title"
-        >
-            &gt;  
-        </h2>
         <Link
-          id="cf-logo-link"
+          replace={false}
           to="/vacolsId/documents"
+          type={null}
         >
-          <Link
-            replace={false}
-            to="/vacolsId/documents"
+          <a
+            href="/vacolsId/documents"
+            onClick={[Function]}
             type={null}
           >
-            <a
-              href="/vacolsId/documents"
-              onClick={[Function]}
-              type={null}
+            <h2
+              className="cf-application-title"
+              id="page-title"
             >
-              <h2
-                className="cf-application-title"
-                id="page-title"
-              >
-                Claims Folder
-              </h2>
-            </a>
-          </Link>
+              Claims Folder
+            </h2>
+          </a>
         </Link>
-      </span>
+      </Link>
     </Route>
     <Route
       key="Document Viewer"
       path="/:vacolsId/documents/:docId"
       render={[Function]}
     >
-      <span
-        data-css-1mdtwij=""
+        &gt;  
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents/docId"
       >
-        <h2
-          className="cf-application-title"
-          id="page-title"
-        >
-            &gt;  
-        </h2>
         <Link
-          id="cf-logo-link"
+          replace={false}
           to="/vacolsId/documents/docId"
+          type={null}
         >
-          <Link
-            replace={false}
-            to="/vacolsId/documents/docId"
+          <a
+            href="/vacolsId/documents/docId"
+            onClick={[Function]}
             type={null}
           >
-            <a
-              href="/vacolsId/documents/docId"
-              onClick={[Function]}
-              type={null}
+            <h2
+              className="cf-application-title"
+              id="page-title"
             >
-              <h2
-                className="cf-application-title"
-                id="page-title"
-              >
-                Document Viewer
-              </h2>
-            </a>
-          </Link>
+              Document Viewer
+            </h2>
+          </a>
         </Link>
-      </span>
+      </Link>
     </Route>
-  </span>
+  </div>
 </Breadcrumbs>
 ```
 

--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -4,9 +4,8 @@
 
 ```
 <Breadcrumbs
-  caretBeforeCrumb={true}
+  caretBeforeAllCrumbs={true}
   getBreadcrumbLabel={[Function]}
-  getElements={[Function]}
   styling={
     Object {
       "data-css-1mdtwij": "",
@@ -16,41 +15,6 @@
   <div
     data-css-1mdtwij=""
   >
-    <Route
-      key="Claims Folder"
-      path="/:vacolsId/documents"
-      render={[Function]}
-    >
-        &gt;  
-      <Link
-        classNames={
-          Array [
-            "cf-btn-link",
-          ]
-        }
-        id="cf-logo-link"
-        to="/vacolsId/documents"
-      >
-        <Link
-          replace={false}
-          to="/vacolsId/documents"
-          type={null}
-        >
-          <a
-            href="/vacolsId/documents"
-            onClick={[Function]}
-            type={null}
-          >
-            <h2
-              className="cf-application-title"
-              id="page-title"
-            >
-              Claims Folder
-            </h2>
-          </a>
-        </Link>
-      </Link>
-    </Route>
     <Route
       key="Document Viewer"
       path="/:vacolsId/documents/:docId"
@@ -86,6 +50,41 @@
         </Link>
       </Link>
     </Route>
+    <Route
+      key="Claims Folder"
+      path="/:vacolsId/documents"
+      render={[Function]}
+    >
+        &gt;  
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents"
+      >
+        <Link
+          replace={false}
+          to="/vacolsId/documents"
+          type={null}
+        >
+          <a
+            href="/vacolsId/documents"
+            onClick={[Function]}
+            type={null}
+          >
+            <h2
+              className="cf-application-title"
+              id="page-title"
+            >
+              Claims Folder
+            </h2>
+          </a>
+        </Link>
+      </Link>
+    </Route>
   </div>
 </Breadcrumbs>
 ```
@@ -94,9 +93,24 @@
 
 ```
 <Breadcrumbs
-  caretBeforeCrumb={false}
+  caretBeforeAllCrumbs={false}
+  elements={
+    Array [
+      Object {
+        "breadcrumb": "Document Viewer",
+        "path": "/:vacolsId/documents/:docId",
+      },
+      Object {
+        "breadcrumb": "Claims Folder",
+        "path": "/:vacolsId/documents",
+      },
+      Object {
+        "breadcrumb": "Assignments | Caseflow Reader",
+        "path": "/",
+      },
+    ]
+  }
   getBreadcrumbLabel={[Function]}
-  getElements={[Function]}
   styling={
     Object {
       "data-css-c6mfa5": "",
@@ -107,8 +121,8 @@
     data-css-c6mfa5=""
   >
     <Route
-      key="Assignments | Caseflow Reader"
-      path="/"
+      key="Document Viewer"
+      path="/:vacolsId/documents/:docId"
       render={[Function]}
     >
       <Link
@@ -118,19 +132,19 @@
           ]
         }
         id="cf-logo-link"
-        to="/"
+        to="/vacolsId/documents/docId"
       >
         <Link
           replace={false}
-          to="/"
+          to="/vacolsId/documents/docId"
           type={null}
         >
           <a
-            href="/"
+            href="/vacolsId/documents/docId"
             onClick={[Function]}
             type={null}
           >
-            Assignments | Caseflow Reader
+            Document Viewer
           </a>
         </Link>
       </Link>
@@ -167,8 +181,8 @@
         &gt;  
     </Route>
     <Route
-      key="Document Viewer"
-      path="/:vacolsId/documents/:docId"
+      key="Assignments | Caseflow Reader"
+      path="/"
       render={[Function]}
     >
       <Link
@@ -178,19 +192,19 @@
           ]
         }
         id="cf-logo-link"
-        to="/vacolsId/documents/docId"
+        to="/"
       >
         <Link
           replace={false}
-          to="/vacolsId/documents/docId"
+          to="/"
           type={null}
         >
           <a
-            href="/vacolsId/documents/docId"
+            href="/"
             onClick={[Function]}
             type={null}
           >
-            Document Viewer
+            Assignments | Caseflow Reader
           </a>
         </Link>
       </Link>

--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -4,8 +4,8 @@
 
 ```
 <Breadcrumbs
-  caretBeforeAllCrumbs={true}
   getBreadcrumbLabel={[Function]}
+  shouldDrawCaretBeforeFirstCrumb={true}
   styling={
     Object {
       "data-css-1mdtwij": "",
@@ -93,7 +93,6 @@
 
 ```
 <Breadcrumbs
-  caretBeforeAllCrumbs={false}
   elements={
     Array [
       Object {
@@ -111,6 +110,7 @@
     ]
   }
   getBreadcrumbLabel={[Function]}
+  shouldDrawCaretBeforeFirstCrumb={false}
   styling={
     Object {
       "data-css-c6mfa5": "",

--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -148,13 +148,13 @@
           </a>
         </Link>
       </Link>
-        &gt;  
     </Route>
     <Route
       key="Claims Folder"
       path="/:vacolsId/documents"
       render={[Function]}
     >
+        &gt;  
       <Link
         classNames={
           Array [
@@ -178,13 +178,13 @@
           </a>
         </Link>
       </Link>
-        &gt;  
     </Route>
     <Route
       key="Assignments | Caseflow Reader"
       path="/"
       render={[Function]}
     >
+        &gt;  
       <Link
         classNames={
           Array [

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -26,15 +26,11 @@ const getBreadcrumbLabel = (route) => <h2 id="page-title" className="cf-applicat
 
 export default class Breadcrumbs extends React.Component {
   renderBreadcrumb = (props, route, idx) => {
-    const { caretBeforeAllCrumbs } = this.props;
+    const { shouldDrawCaretBeforeFirstCrumb } = this.props;
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
-    const caretPositions = {
-      before: caretBeforeAllCrumbs,
-      after: !caretBeforeAllCrumbs && idx > 0
-    };
 
     return <React.Fragment>
-      {(caretPositions.before || caretPositions.after) && caret}
+      {(shouldDrawCaretBeforeFirstCrumb || idx > 0) && caret}
       <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
         {this.props.getBreadcrumbLabel(route)}
       </Link>
@@ -68,11 +64,11 @@ Breadcrumbs.propTypes = {
   })),
   getBreadcrumbLabel: PropTypes.func,
   styling: PropTypes.object,
-  caretBeforeAllCrumbs: PropTypes.bool
+  shouldDrawCaretBeforeFirstCrumb: PropTypes.bool
 };
 
 Breadcrumbs.defaultProps = {
   getBreadcrumbLabel,
-  caretBeforeAllCrumbs: true,
+  shouldDrawCaretBeforeFirstCrumb: true,
   styling: STYLES.APPLICATION_TITLE
 };

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -25,20 +25,19 @@ const getBreadcrumbLabel = (route) => <h2 id="page-title" className="cf-applicat
 </h2>;
 
 export default class Breadcrumbs extends React.PureComponent {
-  renderBreadcrumb = (props, route, idx, arr) => {
+  renderBreadcrumb = (props, route, idx) => {
     const { caretBeforeAllCrumbs } = this.props;
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
     const caretPositions = {
       before: caretBeforeAllCrumbs,
-      after: !caretBeforeAllCrumbs && idx < arr.length - 1
+      after: !caretBeforeAllCrumbs && idx > 0
     };
 
     return <React.Fragment>
-      {caretPositions.before && caret}
+      {(caretPositions.before || caretPositions.after) && caret}
       <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
         {this.props.getBreadcrumbLabel(route)}
       </Link>
-      {caretPositions.after && caret}
     </React.Fragment>;
   };
 
@@ -50,11 +49,11 @@ export default class Breadcrumbs extends React.PureComponent {
     const children = elements || getElementsWithBreadcrumbs(this);
 
     const breadcrumbComponents = _.sortBy(children, 'length').
-      map((route, idx, arr) =>
+      map((route, idx) =>
         <Route
           key={route.breadcrumb}
           path={route.path}
-          render={(props) => this.renderBreadcrumb(props, route, idx, arr)} />
+          render={(props) => this.renderBreadcrumb(props, route, idx)} />
       );
 
     return <div {...styling}>{breadcrumbComponents}</div>;

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -28,10 +28,10 @@ export default class Breadcrumbs extends React.PureComponent {
   render = () => {
     const {
       styling,
-      getElements,
-      caretBeforeAllCrumbs
+      caretBeforeAllCrumbs,
+      elements
     } = this.props;
-    const children = getElements(this);
+    const children = elements || getElementsWithBreadcrumbs(this);
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
 
     let breadcrumbComponents = _.sortBy(children, 'length').
@@ -67,13 +67,12 @@ Breadcrumbs.propTypes = {
     })
   ]),
   styling: PropTypes.object,
-  getElements: PropTypes.func,
+  elements: PropTypes.array,
   caretBeforeAllCrumbs: PropTypes.bool
 };
 
 Breadcrumbs.defaultProps = {
   getBreadcrumbLabel,
-  getElements: getElementsWithBreadcrumbs,
   caretBeforeAllCrumbs: true,
   styling: STYLES.APPLICATION_TITLE
 };

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -29,7 +29,7 @@ export default class Breadcrumbs extends React.PureComponent {
     const {
       styling,
       getElements,
-      caretBeforeCrumb
+      caretBeforeAllCrumbs
     } = this.props;
     const children = getElements(this);
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
@@ -50,7 +50,7 @@ export default class Breadcrumbs extends React.PureComponent {
         value();
     }
 
-    if (caretBeforeCrumb && breadcrumbComponents.length) {
+    if (caretBeforeAllCrumbs && breadcrumbComponents.length) {
       breadcrumbComponents.splice(0, 0, caret);
     }
 
@@ -68,12 +68,12 @@ Breadcrumbs.propTypes = {
   ]),
   styling: PropTypes.object,
   getElements: PropTypes.func,
-  caretBeforeCrumb: PropTypes.bool
+  caretBeforeAllCrumbs: PropTypes.bool
 };
 
 Breadcrumbs.defaultProps = {
   getBreadcrumbLabel,
   getElements: getElementsWithBreadcrumbs,
-  caretBeforeCrumb: true,
+  caretBeforeAllCrumbs: true,
   styling: STYLES.APPLICATION_TITLE
 };

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -34,18 +34,25 @@ export default class Breadcrumbs extends React.PureComponent {
     const children = getElements(this);
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
 
-    const breadcrumbComponents = _.sortBy(children, ({ path }) => path.length).
-      map((route, idx) =>
+    let breadcrumbComponents = _.sortBy(children, 'length').
+      map((route) =>
         <Route key={route.breadcrumb} path={route.path} render={(props) =>
-          <React.Fragment>
-            {caretBeforeCrumb && caret}
-            <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
-              {this.props.getBreadcrumbLabel(route)}
-            </Link>
-            {(!caretBeforeCrumb && idx + 1 < children.length) && caret}
-          </React.Fragment>
+          <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
+            {this.props.getBreadcrumbLabel(route)}
+          </Link>
         } />
       );
+
+    if (breadcrumbComponents.length > 1) {
+      breadcrumbComponents = _(breadcrumbComponents).
+        zip(new Array(breadcrumbComponents.length - 1).fill(caret)).
+        flatten().
+        value();
+    }
+
+    if (caretBeforeCrumb && breadcrumbComponents.length) {
+      breadcrumbComponents.splice(0, 0, caret);
+    }
 
     return <div {...styling}>{breadcrumbComponents}</div>;
   };

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -24,7 +24,7 @@ const getBreadcrumbLabel = (route) => <h2 id="page-title" className="cf-applicat
   {route.breadcrumb}
 </h2>;
 
-export default class Breadcrumbs extends React.PureComponent {
+export default class Breadcrumbs extends React.Component {
   renderBreadcrumb = (props, route, idx) => {
     const { caretBeforeAllCrumbs } = this.props;
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -25,49 +25,50 @@ const getBreadcrumbLabel = (route) => <h2 id="page-title" className="cf-applicat
 </h2>;
 
 export default class Breadcrumbs extends React.PureComponent {
-  render = () => {
+  renderBreadcrumb = (props, route, idx, arr) => {
+    const { caretBeforeAllCrumbs } = this.props;
+    const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
+    const caretPositions = {
+      before: caretBeforeAllCrumbs,
+      after: !caretBeforeAllCrumbs && idx < arr.length - 1
+    };
+
+    return <React.Fragment>
+      {caretPositions.before && caret}
+      <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
+        {this.props.getBreadcrumbLabel(route)}
+      </Link>
+      {caretPositions.after && caret}
+    </React.Fragment>;
+  };
+
+  render() {
     const {
-      styling,
-      caretBeforeAllCrumbs,
-      elements
+      elements,
+      styling
     } = this.props;
     const children = elements || getElementsWithBreadcrumbs(this);
-    const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
 
-    let breadcrumbComponents = _.sortBy(children, 'length').
-      map((route) =>
-        <Route key={route.breadcrumb} path={route.path} render={(props) =>
-          <Link id="cf-logo-link" to={props.match.url} classNames={['cf-btn-link']}>
-            {this.props.getBreadcrumbLabel(route)}
-          </Link>
-        } />
+    const breadcrumbComponents = _.sortBy(children, 'length').
+      map((route, idx, arr) =>
+        <Route
+          key={route.breadcrumb}
+          path={route.path}
+          render={(props) => this.renderBreadcrumb(props, route, idx, arr)} />
       );
 
-    if (breadcrumbComponents.length > 1) {
-      breadcrumbComponents = _(breadcrumbComponents).
-        zip(new Array(breadcrumbComponents.length - 1).fill(caret)).
-        flatten().
-        value();
-    }
-
-    if (caretBeforeAllCrumbs && breadcrumbComponents.length) {
-      breadcrumbComponents.splice(0, 0, caret);
-    }
-
     return <div {...styling}>{breadcrumbComponents}</div>;
-  };
+  }
 }
 
 Breadcrumbs.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.shape({
-      path: PropTypes.string,
-      breadcrumb: PropTypes.string
-    })
-  ]),
+  children: PropTypes.node,
+  elements: PropTypes.arrayOf(PropTypes.shape({
+    path: PropTypes.string,
+    breadcrumb: PropTypes.string
+  })),
+  getBreadcrumbLabel: PropTypes.func,
   styling: PropTypes.object,
-  elements: PropTypes.array,
   caretBeforeAllCrumbs: PropTypes.bool
 };
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.9",
     "mocha": "^4.1.0",
+    "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "sinon": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/caseflow-frontend-toolkit",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Build tools and React components for the Caseflow frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/caseflow-frontend-toolkit.git",

--- a/test/karma/components/Breadcrumbs-test.jsx
+++ b/test/karma/components/Breadcrumbs-test.jsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { MemoryRouter } from 'react-router-dom';
 import Breadcrumbs from '../../../components/Breadcrumbs';
+import { css } from 'glamor';
 
 describe('Breadcrumbs', () => {
   it('renders with props', () =>
@@ -21,6 +22,33 @@ describe('Breadcrumbs', () => {
               path="/"
               title="Assignments | Caseflow Reader" />
           </Breadcrumbs>
+        </MemoryRouter>
+      ).find(Breadcrumbs))
+    ).to.matchSnapshot()
+  );
+
+  it('renders array of crumbs, custom label fn, styling, without initial caret', () =>
+    expect(
+      toJson(mount(
+        <MemoryRouter initialEntries={['/vacolsId/documents/docId']}>
+          <Breadcrumbs
+            getBreadcrumbLabel={((route) => route.breadcrumb)}
+            caretBeforeCrumb={false}
+            styling={css({
+              marginTop: '-1.5rem',
+              marginBottom: '-1.5rem'
+            })}
+            getElements={() => [{
+              breadcrumb: 'Document Viewer',
+              path: '/:vacolsId/documents/:docId'
+            }, {
+              breadcrumb: 'Claims Folder',
+              path: '/:vacolsId/documents'
+            }, {
+              breadcrumb: 'Assignments | Caseflow Reader',
+              path: '/'
+            }]}
+          />
         </MemoryRouter>
       ).find(Breadcrumbs))
     ).to.matchSnapshot()

--- a/test/karma/components/Breadcrumbs-test.jsx
+++ b/test/karma/components/Breadcrumbs-test.jsx
@@ -33,7 +33,7 @@ describe('Breadcrumbs', () => {
         <MemoryRouter initialEntries={['/vacolsId/documents/docId']}>
           <Breadcrumbs
             getBreadcrumbLabel={((route) => route.breadcrumb)}
-            caretBeforeAllCrumbs={false}
+            shouldDrawCaretBeforeFirstCrumb={false}
             styling={css({
               marginTop: '-1.5rem',
               marginBottom: '-1.5rem'

--- a/test/karma/components/Breadcrumbs-test.jsx
+++ b/test/karma/components/Breadcrumbs-test.jsx
@@ -33,12 +33,12 @@ describe('Breadcrumbs', () => {
         <MemoryRouter initialEntries={['/vacolsId/documents/docId']}>
           <Breadcrumbs
             getBreadcrumbLabel={((route) => route.breadcrumb)}
-            caretBeforeCrumb={false}
+            caretBeforeAllCrumbs={false}
             styling={css({
               marginTop: '-1.5rem',
               marginBottom: '-1.5rem'
             })}
-            getElements={() => [{
+            elements={[{
               breadcrumb: 'Document Viewer',
               path: '/:vacolsId/documents/:docId'
             }, {


### PR DESCRIPTION
Connects #19

For testing: `Breadcrumbs` is implemented outside `NavigationBar` in Queue task detail views (https://github.com/department-of-veterans-affairs/caseflow/pull/4634). Run `yarn link` from this repo, and then `yarn link "@department-of-veterans-affairs/caseflow-frontend-toolkit"` in `caseflow/client`

## AC
- [ ] Navigate to `/queue/tasks/:id`, observe breadcrumbs
- [ ] Click "Open documents in Caseflow Reader" (navigate to `/reader/appeal/:id/documents/:doc_id`), observe breadcrumbs as before