### PR TITLE
Breadcrumbs | Add option to render all breadcrumbs regardless of route

### DIFF
--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -5,6 +5,7 @@
 ```
 <Breadcrumbs
   getBreadcrumbLabel={[Function]}
+  renderAllCrumbs={false}
   shouldDrawCaretBeforeFirstCrumb={true}
   styling={
     Object {
@@ -110,6 +111,7 @@
     ]
   }
   getBreadcrumbLabel={[Function]}
+  renderAllCrumbs={false}
   shouldDrawCaretBeforeFirstCrumb={false}
   styling={
     Object {
@@ -212,3 +214,139 @@
   </div>
 </Breadcrumbs>
 ```
+
+#### `renders an array of crumbs regardless of route`
+
+```
+<Breadcrumbs
+  elements={
+    Array [
+      Object {
+        "breadcrumb": "Your Queue",
+        "path": "/",
+      },
+      Object {
+        "breadcrumb": "Vet. E Ran",
+        "path": "/tasks/:vacolsId",
+      },
+      Object {
+        "breadcrumb": "Select Dispositions",
+        "path": "/tasks/:vacolsId/dispositions",
+      },
+      Object {
+        "breadcrumb": "Submit Draft Decision",
+        "path": "/tasks/:vacolsId/submit",
+      },
+    ]
+  }
+  getBreadcrumbLabel={[Function]}
+  renderAllCrumbs={true}
+  shouldDrawCaretBeforeFirstCrumb={false}
+  styling={
+    Object {
+      "data-css-c6mfa5": "",
+    }
+  }
+>
+  <div
+    data-css-c6mfa5=""
+  >
+    <Link
+      classNames={
+        Array [
+          "cf-btn-link",
+        ]
+      }
+      id="cf-logo-link"
+      to="/"
+    >
+      <Link
+        replace={false}
+        to="/"
+        type={null}
+      >
+        <a
+          href="/"
+          onClick={[Function]}
+          type={null}
+        >
+          Your Queue
+        </a>
+      </Link>
+    </Link>
+      &gt;  
+    <Link
+      classNames={
+        Array [
+          "cf-btn-link",
+        ]
+      }
+      id="cf-logo-link"
+      to="/tasks/:vacolsId"
+    >
+      <Link
+        replace={false}
+        to="/tasks/:vacolsId"
+        type={null}
+      >
+        <a
+          href="/tasks/:vacolsId"
+          onClick={[Function]}
+          type={null}
+        >
+          Vet. E Ran
+        </a>
+      </Link>
+    </Link>
+      &gt;  
+    <Link
+      classNames={
+        Array [
+          "cf-btn-link",
+        ]
+      }
+      id="cf-logo-link"
+      to="/tasks/:vacolsId/dispositions"
+    >
+      <Link
+        replace={false}
+        to="/tasks/:vacolsId/dispositions"
+        type={null}
+      >
+        <a
+          href="/tasks/:vacolsId/dispositions"
+          onClick={[Function]}
+          type={null}
+        >
+          Select Dispositions
+        </a>
+      </Link>
+    </Link>
+      &gt;  
+    <Link
+      classNames={
+        Array [
+          "cf-btn-link",
+        ]
+      }
+      id="cf-logo-link"
+      to="/tasks/:vacolsId/submit"
+    >
+      <Link
+        replace={false}
+        to="/tasks/:vacolsId/submit"
+        type={null}
+      >
+        <a
+          href="/tasks/:vacolsId/submit"
+          onClick={[Function]}
+          type={null}
+        >
+          Submit Draft Decision
+        </a>
+      </Link>
+    </Link>
+  </div>
+</Breadcrumbs>
+```
+

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -25,7 +25,7 @@ const getBreadcrumbLabel = (route) => <h2 id="page-title" className="cf-applicat
 </h2>;
 
 export default class Breadcrumbs extends React.Component {
-  renderBreadcrumb = (props, route, idx) => {
+  renderBreadcrumbContent = (props, route, idx) => {
     const { shouldDrawCaretBeforeFirstCrumb } = this.props;
     const caret = <React.Fragment>&nbsp;&nbsp;&gt;&nbsp;&nbsp;</React.Fragment>;
 
@@ -37,20 +37,26 @@ export default class Breadcrumbs extends React.Component {
     </React.Fragment>;
   };
 
+  getCrumb = (route, idx) => {
+    if (this.props.renderAllCrumbs) {
+      return <React.Fragment>
+        {this.renderBreadcrumbContent({ match: { url: route.path } }, route, idx)}
+      </React.Fragment>;
+    }
+
+    return <Route
+      key={route.breadcrumb}
+      path={route.path}
+      render={(props) => this.renderBreadcrumbContent(props, route, idx)} />;
+  };
+
   render() {
     const {
       elements,
       styling
     } = this.props;
     const children = elements || getElementsWithBreadcrumbs(this);
-
-    const breadcrumbComponents = _.sortBy(children, 'length').
-      map((route, idx) =>
-        <Route
-          key={route.breadcrumb}
-          path={route.path}
-          render={(props) => this.renderBreadcrumb(props, route, idx)} />
-      );
+    const breadcrumbComponents = _.sortBy(children, 'length').map(this.getCrumb);
 
     return <div {...styling}>{breadcrumbComponents}</div>;
   }
@@ -64,11 +70,13 @@ Breadcrumbs.propTypes = {
   })),
   getBreadcrumbLabel: PropTypes.func,
   styling: PropTypes.object,
-  shouldDrawCaretBeforeFirstCrumb: PropTypes.bool
+  shouldDrawCaretBeforeFirstCrumb: PropTypes.bool,
+  renderAllCrumbs: PropTypes.bool
 };
 
 Breadcrumbs.defaultProps = {
   getBreadcrumbLabel,
   shouldDrawCaretBeforeFirstCrumb: true,
-  styling: STYLES.APPLICATION_TITLE
+  styling: STYLES.APPLICATION_TITLE,
+  renderAllCrumbs: false
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/caseflow-frontend-toolkit",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Build tools and React components for the Caseflow frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/caseflow-frontend-toolkit.git",

--- a/test/karma/components/Breadcrumbs-test.jsx
+++ b/test/karma/components/Breadcrumbs-test.jsx
@@ -32,7 +32,7 @@ describe('Breadcrumbs', () => {
       toJson(mount(
         <MemoryRouter initialEntries={['/vacolsId/documents/docId']}>
           <Breadcrumbs
-            getBreadcrumbLabel={((route) => route.breadcrumb)}
+            getBreadcrumbLabel={(route) => route.breadcrumb}
             shouldDrawCaretBeforeFirstCrumb={false}
             styling={css({
               marginTop: '-1.5rem',
@@ -47,6 +47,37 @@ describe('Breadcrumbs', () => {
             }, {
               breadcrumb: 'Assignments | Caseflow Reader',
               path: '/'
+            }]}
+          />
+        </MemoryRouter>
+      ).find(Breadcrumbs))
+    ).to.matchSnapshot()
+  );
+
+  it('renders an array of crumbs regardless of route', () =>
+    expect(
+      toJson(mount(
+        <MemoryRouter initialEntries={['/vacolsId/documents/docId']}>
+          <Breadcrumbs
+            getBreadcrumbLabel={(route) => route.breadcrumb}
+            shouldDrawCaretBeforeFirstCrumb={false}
+            renderAllCrumbs
+            styling={css({
+              marginTop: '-1.5rem',
+              marginBottom: '-1.5rem'
+            })}
+            elements={[{
+              breadcrumb: 'Your Queue',
+              path: '/'
+            }, {
+              breadcrumb: 'Vet. E Ran',
+              path: '/tasks/:vacolsId'
+            }, {
+              breadcrumb: 'Select Dispositions',
+              path: '/tasks/:vacolsId/dispositions'
+            }, {
+              breadcrumb: 'Submit Draft Decision',
+              path: '/tasks/:vacolsId/submit'
             }]}
           />
         </MemoryRouter>


### PR DESCRIPTION
In Caseflow Queue, we use Breadcrumbs to indicate the user's progress through multi-step processes. These processes may reuse routes/steps, and may not always have steps nested sequentially, such that all `Route`s may not be rendered at any given time. To get around this, we render a `Link` outside a `Route` (whose visibility state is governed by the browser path)

Implemented in https://github.com/department-of-veterans-affairs/caseflow/pull/4736

## AC
- [ ] Check out Caseflow `issue4471`, `yarn link` this
- [ ] `FeatureToggle.enable!(:queue_phase_two)`
- [ ] Navigate to `/queue/tasks/:id`, select "Decision Ready for Review" from "Select an action" dropdown
- [ ] Click "Finish Dispositions", confirm you end up at `/queue/tasks/:id/submit`
- [ ] Note that "Select Dispositions" route is still visible, despite its URL (`.../dispositions`) not matching the current route (`.../submit`)