### PR TITLE
Fixing breadcrumbs for path length sorting

### DIFF
--- a/__snapshots__/Breadcrumbs.md
+++ b/__snapshots__/Breadcrumbs.md
@@ -17,41 +17,6 @@
     data-css-1mdtwij=""
   >
     <Route
-      key="Document Viewer"
-      path="/:vacolsId/documents/:docId"
-      render={[Function]}
-    >
-        &gt;  
-      <Link
-        classNames={
-          Array [
-            "cf-btn-link",
-          ]
-        }
-        id="cf-logo-link"
-        to="/vacolsId/documents/docId"
-      >
-        <Link
-          replace={false}
-          to="/vacolsId/documents/docId"
-          type={null}
-        >
-          <a
-            href="/vacolsId/documents/docId"
-            onClick={[Function]}
-            type={null}
-          >
-            <h2
-              className="cf-application-title"
-              id="page-title"
-            >
-              Document Viewer
-            </h2>
-          </a>
-        </Link>
-      </Link>
-    </Route>
-    <Route
       key="Claims Folder"
       path="/:vacolsId/documents"
       render={[Function]}
@@ -81,6 +46,41 @@
               id="page-title"
             >
               Claims Folder
+            </h2>
+          </a>
+        </Link>
+      </Link>
+    </Route>
+    <Route
+      key="Document Viewer"
+      path="/:vacolsId/documents/:docId"
+      render={[Function]}
+    >
+        &gt;  
+      <Link
+        classNames={
+          Array [
+            "cf-btn-link",
+          ]
+        }
+        id="cf-logo-link"
+        to="/vacolsId/documents/docId"
+      >
+        <Link
+          replace={false}
+          to="/vacolsId/documents/docId"
+          type={null}
+        >
+          <a
+            href="/vacolsId/documents/docId"
+            onClick={[Function]}
+            type={null}
+          >
+            <h2
+              className="cf-application-title"
+              id="page-title"
+            >
+              Document Viewer
             </h2>
           </a>
         </Link>
@@ -123,8 +123,8 @@
     data-css-c6mfa5=""
   >
     <Route
-      key="Document Viewer"
-      path="/:vacolsId/documents/:docId"
+      key="Assignments | Caseflow Reader"
+      path="/"
       render={[Function]}
     >
       <Link
@@ -134,19 +134,19 @@
           ]
         }
         id="cf-logo-link"
-        to="/vacolsId/documents/docId"
+        to="/"
       >
         <Link
           replace={false}
-          to="/vacolsId/documents/docId"
+          to="/"
           type={null}
         >
           <a
-            href="/vacolsId/documents/docId"
+            href="/"
             onClick={[Function]}
             type={null}
           >
-            Document Viewer
+            Assignments | Caseflow Reader
           </a>
         </Link>
       </Link>
@@ -182,8 +182,8 @@
       </Link>
     </Route>
     <Route
-      key="Assignments | Caseflow Reader"
-      path="/"
+      key="Document Viewer"
+      path="/:vacolsId/documents/:docId"
       render={[Function]}
     >
         &gt;  
@@ -194,19 +194,19 @@
           ]
         }
         id="cf-logo-link"
-        to="/"
+        to="/vacolsId/documents/docId"
       >
         <Link
           replace={false}
-          to="/"
+          to="/vacolsId/documents/docId"
           type={null}
         >
           <a
-            href="/"
+            href="/vacolsId/documents/docId"
             onClick={[Function]}
             type={null}
           >
-            Assignments | Caseflow Reader
+            Document Viewer
           </a>
         </Link>
       </Link>

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -56,7 +56,12 @@ export default class Breadcrumbs extends React.Component {
       styling
     } = this.props;
     const children = elements || getElementsWithBreadcrumbs(this);
-    const breadcrumbComponents = _.sortBy(children, 'length').map(this.getCrumb);
+
+    // When we're rendering breadcrumbs based on path then we want to sort by
+    // path length to get the correct breadcrumb ordering. Otherwise we want the order
+    // in which we push breadcrumbs.
+    const breadcrumbComponents = this.props.renderAllCrumbs ?
+      children.map(this.getCrumb) : _.sortBy(children, 'path.length').map(this.getCrumb);
 
     return <div {...styling}>{breadcrumbComponents}</div>;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/caseflow-frontend-toolkit",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Build tools and React components for the Caseflow frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/caseflow-frontend-toolkit.git",


### PR DESCRIPTION
Currently Reader breadcrumbs are broken. They do not sort correctly by path length. This corrects that while not changing how Queue uses breadcrumbs.