### PR TITLE
Support `to` or `href` in NavigationBar appName link

### DIFF
--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -71,7 +71,7 @@ export default class NavigationBar extends React.Component {
                 <Link id="cf-logo-link" {...logoLinkProps}>
                   Caseflow
                   <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
-                    &nbsp;&gt; {appName}
+                    &nbsp; {appName && `> ${appName}`}
                   </h2>
                 </Link>
               </h1>

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -46,12 +46,20 @@ export default class NavigationBar extends React.Component {
     const {
       appName,
       defaultUrl,
+      defaultHref,
       dropdownUrls,
       topMessage,
       logoProps,
       wideApp,
       userDisplayName
     } = this.props;
+    const logoLinkProps = {};
+
+    if (defaultUrl) {
+      logoLinkProps.to = defaultUrl;
+    } else if (defaultHref) {
+      logoLinkProps.href = defaultHref;
+    }
 
     return <div>
       <header {...headerStyling}>
@@ -60,10 +68,10 @@ export default class NavigationBar extends React.Component {
             <span className="cf-push-left" {...pushLeftStyling}>
               <CaseflowLogo {...logoProps} />
               <h1 {...h1Styling}>
-                <Link id="cf-logo-link" to={defaultUrl}>
+                <Link id="cf-logo-link" {...logoLinkProps}>
                   Caseflow
                   <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
-                    &nbsp; {appName}
+                    &nbsp;&gt; {appName}
                   </h2>
                 </Link>
               </h1>
@@ -103,7 +111,8 @@ NavigationBar.propTypes = {
     target: PropTypes.string
   })),
   extraBanner: PropTypes.element,
-  defaultUrl: PropTypes.string.isRequired,
+  defaultUrl: PropTypes.string,
+  defaultHref: PropTypes.string,
   userDisplayName: PropTypes.string.isRequired,
   appName: PropTypes.string.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/caseflow-frontend-toolkit",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Build tools and React components for the Caseflow frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/caseflow-frontend-toolkit.git",


### PR DESCRIPTION
For https://github.com/department-of-veterans-affairs/caseflow/issues/4894, we want to support modifying NavigationBar's app name link to support a `href` property, which links to pages outside the app router's base url.

For example, we want to give Queue users a link back to Queue after navigating to Reader. Within Reader, the BrowserRouter's [base url is `/reader/appeal`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/reader/index.jsx#L21), so to navigate to Queue from within that context, we need to set the link's `href`, rather than `to`.