### PR TITLE
Support passing separate links for app name and caseflow logo

### DIFF
--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -46,29 +46,12 @@ export default class NavigationBar extends React.Component {
     const {
       appName,
       defaultUrl,
-      defaultHref,
-      appNameUrl,
       dropdownUrls,
       topMessage,
       logoProps,
       wideApp,
       userDisplayName
     } = this.props;
-    const logoLinkProps = {};
-    const appNameLinkProps = {};
-
-    if (defaultUrl) {
-      logoLinkProps.to = defaultUrl;
-    } else if (defaultHref) {
-      logoLinkProps.href = defaultHref;
-    }
-
-    if (appNameUrl) {
-      appNameLinkProps.to = appNameUrl;
-    } else {
-      // if no separate appNameUrl, link to same dest as logo
-      Object.assign(appNameLinkProps, logoLinkProps);
-    }
 
     return <div>
       <header {...headerStyling}>
@@ -77,10 +60,10 @@ export default class NavigationBar extends React.Component {
             <span className="cf-push-left" {...pushLeftStyling}>
               <CaseflowLogo {...logoProps} />
               <h1 {...h1Styling}>
-                <Link id="cf-logo-link" {...logoLinkProps}>
+                <Link id="cf-logo-link" href="/">
                   Caseflow
                 </Link>
-                {appName && <Link {...appNameLinkProps}>
+                {appName && <Link to={defaultUrl}>
                   <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
                     &gt; {appName}
                   </h2>
@@ -123,8 +106,6 @@ NavigationBar.propTypes = {
   })),
   extraBanner: PropTypes.element,
   defaultUrl: PropTypes.string,
-  appNameUrl: PropTypes.string,
-  defaultHref: PropTypes.string,
   userDisplayName: PropTypes.string.isRequired,
   appName: PropTypes.string.isRequired
 };

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -47,7 +47,7 @@ export default class NavigationBar extends React.Component {
       appName,
       defaultUrl,
       defaultHref,
-      appNameHref,
+      appNameUrl,
       dropdownUrls,
       topMessage,
       logoProps,
@@ -63,10 +63,11 @@ export default class NavigationBar extends React.Component {
       logoLinkProps.href = defaultHref;
     }
 
-    if (appNameHref) {
-      appNameLinkProps.href = appNameHref;
+    if (appNameUrl) {
+      appNameLinkProps.to = appNameUrl;
     } else {
-      appNameLinkProps.to = defaultUrl || defaultHref;
+      // if no separate appNameUrl, link to same dest as logo
+      Object.assign(appNameLinkProps, logoLinkProps);
     }
 
     return <div>
@@ -122,8 +123,8 @@ NavigationBar.propTypes = {
   })),
   extraBanner: PropTypes.element,
   defaultUrl: PropTypes.string,
+  appNameUrl: PropTypes.string,
   defaultHref: PropTypes.string,
-  appNameHref: PropTypes.string,
   userDisplayName: PropTypes.string.isRequired,
   appName: PropTypes.string.isRequired
 };

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -47,6 +47,7 @@ export default class NavigationBar extends React.Component {
       appName,
       defaultUrl,
       defaultHref,
+      appNameHref,
       dropdownUrls,
       topMessage,
       logoProps,
@@ -54,11 +55,18 @@ export default class NavigationBar extends React.Component {
       userDisplayName
     } = this.props;
     const logoLinkProps = {};
+    const appNameLinkProps = {};
 
     if (defaultUrl) {
       logoLinkProps.to = defaultUrl;
     } else if (defaultHref) {
       logoLinkProps.href = defaultHref;
+    }
+
+    if (appNameHref) {
+      appNameLinkProps.href = appNameHref;
+    } else {
+      appNameLinkProps.to = defaultUrl || defaultHref;
     }
 
     return <div>
@@ -70,10 +78,12 @@ export default class NavigationBar extends React.Component {
               <h1 {...h1Styling}>
                 <Link id="cf-logo-link" {...logoLinkProps}>
                   Caseflow
-                  <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
-                    &nbsp; {appName && `> ${appName}`}
-                  </h2>
                 </Link>
+                {appName && <Link {...appNameLinkProps}>
+                  <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
+                    &gt; {appName}
+                  </h2>
+                </Link>}
               </h1>
               <Breadcrumbs>
                 {this.props.children}
@@ -113,6 +123,7 @@ NavigationBar.propTypes = {
   extraBanner: PropTypes.element,
   defaultUrl: PropTypes.string,
   defaultHref: PropTypes.string,
+  appNameHref: PropTypes.string,
   userDisplayName: PropTypes.string.isRequired,
   appName: PropTypes.string.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/caseflow-frontend-toolkit",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Build tools and React components for the Caseflow frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/caseflow-frontend-toolkit.git",


### PR DESCRIPTION
For Queue users who navigate to Reader, we want to give an easy way to navigate back to both Queue and Reader within the navigation bar (c.f. https://github.com/department-of-veterans-affairs/caseflow/issues/5646). This adds support for passing an `appNameHref`, which sets the destination of the app name link. If no `appNameHref` is passed, the Caseflow logo and app name links will use the same destination