### PR TITLE
Allow passing optional element to right side of nav bar

### DIFF
--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -50,6 +50,7 @@ export default class NavigationBar extends React.Component {
       outsideCurrentRouter,
       topMessage,
       logoProps,
+      rightNavElement,
       wideApp,
       userDisplayName
     } = this.props;
@@ -84,6 +85,7 @@ export default class NavigationBar extends React.Component {
               </h2>}
             </nav>
             <span className="cf-push-right">
+              { rightNavElement && rightNavElement }
               <DropdownMenu
                 analyticsTitle={`${appName} Navbar`}
                 options={dropdownUrls}


### PR DESCRIPTION
In preparation for [moving the link to the case search page](https://github.com/department-of-veterans-affairs/caseflow/issues/7016) to the navigation bar, we need to allow elements (namely the case search link) to be passed into the navigation bar. This PR allows that.

We cannot add the link here because it needs to come from within the react router.