### PR TITLE
Add null check for dropdownUrls prop when updating feedback link

### DIFF
--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -57,7 +57,7 @@ export default class NavigationBar extends React.Component {
 
     let targetArgument = { to: defaultUrl };
 
-    const updatedDropdownUrls = dropdownUrls.map((obj) => {
+    const updatedDropdownUrls = (typeof dropdownUrls == 'undefined') ? dropdownUrls : dropdownUrls.map((obj) => {
       return obj.title === 'Send Feedback' ? Object.assign({}, obj,
         { link: `${obj.link}&original_url=${encodeURIComponent(window.location.href)}` }) : obj;
     });

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -57,7 +57,7 @@ export default class NavigationBar extends React.Component {
 
     let targetArgument = { to: defaultUrl };
 
-    const updatedDropdownUrls = (typeof dropdownUrls == 'undefined') ? dropdownUrls : dropdownUrls.map((obj) => {
+    const updatedDropdownUrls = (typeof dropdownUrls === 'undefined') ? dropdownUrls : dropdownUrls.map((obj) => {
       return obj.title === 'Send Feedback' ? Object.assign({}, obj,
         { link: `${obj.link}&original_url=${encodeURIComponent(window.location.href)}` }) : obj;
     });


### PR DESCRIPTION
caseflow/client/test/karma/containers/EstablishClaimContainer-test.js karma test fails since it has null for dropdownUrls prop. Failure can be seen here:
https://circleci.com/gh/department-of-veterans-affairs/caseflow/40827

Instead of fixing the test, this PR introduces null check in case prop has null value. 
Connected to https://github.com/department-of-veterans-affairs/caseflow/pull/9213