### PR TITLE
Adding switch app dropdown

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -14,15 +14,15 @@ const dropdownMenuStyles = css({
   display: 'block'
 });
 
-const dropdownWrapperStyles = css({
-  '& a': {
-    color: COLORS.GREY_MEDIUM
-  },
+// const dropdownWrapperStyles = css({
+//   '& a': {
+//     color: COLORS.GREY_MEDIUM
+//   },
 
-  '& li a:hover': {
-    color: COLORS.WHITE
-  }
-});
+//   '& li a:hover': {
+//     color: COLORS.WHITE
+//   }
+// });
 
 const triggerStyles = css({
   '::after': {
@@ -57,7 +57,7 @@ export default class DropdownMenu extends React.Component {
   }
 
   onClick = (title) => () => {
-    window.analyticsEvent(this.props.analyticsTitle, title.toLowerCase());
+    window.analyticsEvent(this.props.analyticsTitle, title.toString().toLowerCase());
   }
 
   onMenuClick = () => {
@@ -89,7 +89,7 @@ export default class DropdownMenu extends React.Component {
       </ul>;
     };
 
-    return <div ref={this.setWrapperRef} {...dropdownWrapperStyles}
+    return <div ref={this.setWrapperRef}
       className="cf-dropdown" role="dropdown-menu" >
       <a
         {...triggerStyles}

--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -80,7 +80,7 @@ export default class DropdownMenu extends React.Component {
         aria-labelledby="menu-trigger">
         {options.map((option, index) =>
           <li key={index}>
-            {options.length - 1 === index && <div className="dropdown-border"></div>}
+            {option.border && <div className="dropdown-border"></div>}
             <Link
               href={option.link}
               target={option.target}
@@ -91,7 +91,7 @@ export default class DropdownMenu extends React.Component {
 
     return <div ref={this.setWrapperRef} {...dropdownWrapperStyles}
       className="cf-dropdown" role="dropdown-menu" >
-      <a href="#dropdown-menu"
+      <a
         {...triggerStyles}
         className="cf-dropdown-trigger"
         id="menu-trigger"
@@ -108,6 +108,7 @@ DropdownMenu.propTypes = {
   options: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
+    border: PropTypes.boolean,
     target: PropTypes.string
   })),
   label: PropTypes.string.isRequired

--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from './Link';
 import { css } from 'glamor';
-import { COLORS } from '../util/StyleConstants';
 
 // Lots of this class are taken from
 // https://stackoverflow.com/questions/32553158/detect-click-outside-react-component

--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -14,16 +14,6 @@ const dropdownMenuStyles = css({
   display: 'block'
 });
 
-// const dropdownWrapperStyles = css({
-//   '& a': {
-//     color: COLORS.GREY_MEDIUM
-//   },
-
-//   '& li a:hover': {
-//     color: COLORS.WHITE
-//   }
-// });
-
 const triggerStyles = css({
   '::after': {
     backgroundSize: '.75em'

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -47,6 +47,7 @@ export default class NavigationBar extends React.Component {
       appName,
       defaultUrl,
       dropdownUrls,
+      applicationUrls,
       outsideCurrentRouter,
       topMessage,
       logoProps,
@@ -73,7 +74,7 @@ export default class NavigationBar extends React.Component {
                 </Link>
                 {appName && <Link {...targetArgument}>
                   <h2 id="page-title" className="cf-application-title" {...STYLES.APPLICATION_TITLE}>
-                    &gt; {appName}
+                    {appName}
                   </h2>
                 </Link>}
               </h1>
@@ -83,6 +84,19 @@ export default class NavigationBar extends React.Component {
               {topMessage && <h2 className="cf-application-title" {...STYLES.APPLICATION_TITLE} {...topMessageStyling}>
                  &nbsp; | &nbsp; {topMessage}
               </h2>}
+              { applicationUrls &&
+                <span>&nbsp; | &nbsp;
+                  <DropdownMenu
+                    analyticsTitle={`${appName} Switch App`}
+                    options={applicationUrls.map((option) => {
+                      return {
+                        ...option,
+                        title: <span><b>Caseflow</b> {option.title}</span>
+                      };
+                    })}
+                    label="Switch product"
+                  />
+                </span>}
             </nav>
             <span className="cf-push-right">
               { rightNavElement && rightNavElement }
@@ -108,10 +122,17 @@ NavigationBar.defaultProps = {
 };
 
 NavigationBar.propTypes = {
+  applicationUrls: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired,
+    target: PropTypes.string,
+    border: PropTypes.boolean
+  })),
   dropdownUrls: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
-    target: PropTypes.string
+    target: PropTypes.string,
+    border: PropTypes.boolean
   })),
   extraBanner: PropTypes.element,
   defaultUrl: PropTypes.string,


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/caseflow/issues/7503

Add a new `applicationUrls` prop to the Navigation component. This will populate a switch application dropdown:

![screen shot 2019-02-11 at 1 51 57 pm](https://user-images.githubusercontent.com/3885236/52595088-0981b180-2e1b-11e9-8872-d5ff7aeba19d.png)
