### PR TITLE
Allow the 'replace' property to be passed to RouterLink

### DIFF
--- a/components/Link.jsx
+++ b/components/Link.jsx
@@ -63,6 +63,7 @@ export default class Link extends React.Component {
       href,
       button,
       children,
+      replace,
       disabled
     } = this.props;
 
@@ -97,7 +98,7 @@ export default class Link extends React.Component {
     };
 
     if (to) {
-      return <RouterLink to={to} {...commonProps}>
+      return <RouterLink to={to} replace={replace} {...commonProps}>
         {children}
       </RouterLink>;
     }
@@ -119,5 +120,6 @@ Link.propTypes = {
   onMouseUp: PropTypes.func,
   onClick: PropTypes.func,
   children: PropTypes.node,
+  replace: PropTypes.bool,
   disabled: PropTypes.bool
 };


### PR DESCRIPTION
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md#replace-bool

This will allow links to be followed without adding another entry to the browser history.