### PR TITLE
Keyboard Access to Navigation Bar

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -80,7 +80,7 @@ export default class DropdownMenu extends React.Component {
 
     return <div ref={this.setWrapperRef}
       className="cf-dropdown" role="dropdown-menu" >
-      <a
+      <a href="#"
         {...triggerStyles}
         className="cf-dropdown-trigger"
         id="menu-trigger"


### PR DESCRIPTION
This PR allows keyboard-only users to access the `Switch Product` and the `Change User` dropdown menus in the navigation bar.