### PR TITLE
hotfix/APPEALS-8288 fix dropdown menus that close when clicking scroll bar

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -36,7 +36,9 @@ export default class DropdownMenu extends React.Component {
   setWrapperRef = (node) => this.wrapperRef = node
 
   onClickOutside = (event) => {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.menu) {
+    // event.path is [html, document, Window] when clicking the scroll bar and always more when clicking content
+    // this stops the menu from closing if a user clicks to use the scroll bar with the menu open
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && event.path[2] !== window && this.state.menu) {
       window.analyticsEvent(this.props.analyticsTitle, 'menu', 'blur');
 
       this.setState({


### PR DESCRIPTION
Resolves [APPEALS-8288](https://vajira.max.gov/browse/APPEALS-8288)

### Description
Added a check to the mousedown event handler to not close the dropdown menu if a user clicks to use the scroll bar

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Menus listed on associated research story do not close when clicking on the scroll bar
