### PR TITLE
Hotfix/appeals 10422 remove dead caseflow status link

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -36,7 +36,9 @@ export default class DropdownMenu extends React.Component {
   setWrapperRef = (node) => this.wrapperRef = node
 
   onClickOutside = (event) => {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.menu) {
+    // event.path is [html, document, Window] when clicking the scroll bar and always more when clicking content
+    // this stops the menu from closing if a user clicks to use the scroll bar with the menu open
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && event.path[2] !== window && this.state.menu) {
       window.analyticsEvent(this.props.analyticsTitle, 'menu', 'blur');
 
       this.setState({

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -13,10 +13,6 @@ const footerStyles = css({
     height: 'auto'
   }
 });
-const barStyling = css({
-  marginLeft: '1rem',
-  marginRight: '1rem'
-});
 
 export default class Footer extends React.Component {
   onFeedbackClick = () => {
@@ -29,15 +25,9 @@ export default class Footer extends React.Component {
       feedbackUrl
     } = this.props;
 
-    const statusPage = 'https://caseflow.statuspage.io';
-
     return <footer className="cf-app-footer" {...footerStyles}>
       <div {...getAppWidthStyling(wideApp)}>
         <div className="cf-push-right">
-          <Link
-            href={statusPage}
-            target="_blank">Track Caseflow Status</Link>
-          <span {...barStyling}>|</span>
           <Link
             href={feedbackUrl}
             target="_blank"


### PR DESCRIPTION
Resolves [APPEALS-10422](https://vajira.max.gov/browse/APPEALS-10422)

- Removes dead link "Track Caseflow Status" from the footer component
- Removes the <span> styling the pipe between links
- Removes <span> style and status page link constants