### PR TITLE
hotfix/APPEALS-13759: Browser Deprecation of event.path

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -29,9 +29,15 @@ export default class DropdownMenu extends React.Component {
     };
   }
 
-  componentDidMount = () => document.addEventListener('mousedown', this.onClickOutside);
+  componentDidMount = () => {
+    document.addEventListener('mousedown', this.onClickOutside);
+    document.addEventListener('keydown', this.onClickOutside);
+  }
 
-  componentWillUnmount = () => document.removeEventListener('mousedown', this.onClickOutside);
+  componentWillUnmount = () => {
+    document.removeEventListener('mousedown', this.onClickOutside);
+    document.removeEventListener('keydown', this.onClickOutside);
+  }
 
   setWrapperRef = (node) => this.wrapperRef = node
 
@@ -45,6 +51,11 @@ export default class DropdownMenu extends React.Component {
       this.setState({
         menu: false
       });
+    } else if (event.key === 'Escape') {
+      this.setState({
+        menu: false
+      });
+      event.preventDefault();
     }
   }
 

--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -36,9 +36,10 @@ export default class DropdownMenu extends React.Component {
   setWrapperRef = (node) => this.wrapperRef = node
 
   onClickOutside = (event) => {
-    // event.path is [html, document, Window] when clicking the scroll bar and always more when clicking content
+    // event.composedPath() is [html, document, Window] when clicking the scroll bar and more when clicking content
     // this stops the menu from closing if a user clicks to use the scroll bar with the menu open
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && event.path[2] !== window && this.state.menu) {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target) &&
+      event.composedPath()[2] !== window && this.state.menu) {
       window.analyticsEvent(this.props.analyticsTitle, 'menu', 'blur');
 
       this.setState({


### PR DESCRIPTION
Resolves [APPEALS-13759](https://vajira.max.gov/browse/APPEALS-13759)

### Description
Added a check to the mousedown event handler to not close the dropdown menu if a user clicks to use the scroll bar

Link to deprecation page: https://chromestatus.com/feature/5726124632965120

Link to associated caseflow PR: https://github.com/department-of-veterans-affairs/caseflow/pull/17938

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Menus in caseflow no longer cause a console error and can once again be closed by clicking outside the menu or by using escape key

