### PR TITLE
APPEALS-29282: expand DropdownMenu propTypes to include react elements

### DIFF
--- a/components/DropdownMenu.jsx
+++ b/components/DropdownMenu.jsx
@@ -116,7 +116,10 @@ export default class DropdownMenu extends React.Component {
 DropdownMenu.propTypes = {
   analyticsTitle: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.string.isRequired,
+    title: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
+    ]).isRequired,
     link: PropTypes.string.isRequired,
     border: PropTypes.bool,
     target: PropTypes.string


### PR DESCRIPTION

[APPEALS-29282](https://jira.devops.va.gov/browse/APPEALS-29282)

This PR fixes the following: DropdownMenu emits propTypes warnings because NavigationBar passes a \<span\> as a title.

To test:

1. Log in as CAMOADMIN, navigate to queue
2. make sure the console warning from the ticket is gone